### PR TITLE
fix: add index.d.ts to the list of published files

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   },
   "types": "index.d.ts",
   "files": [
-    "lib"
+    "lib",
+    "index.d.ts"
   ],
   "scripts": {
     "build": "true",


### PR DESCRIPTION
`package.json` mentions `index.d.ts` in the `types` field, but that file is not published to `npm`. This causes errors with projects using TypeScript.